### PR TITLE
Add functionality to get a list of comments by article id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -117,7 +117,6 @@ describe('/api/articles', () => {
 				.get('/api/articles')
 				.expect(200)
 				.then(({ body: { articles } }) => {
-					expect(articles).toBeInstanceOf(Array);
 					expect(articles).toHaveLength(12);
 					articles.forEach(article => {
 						let commentCount = commentData
@@ -160,7 +159,6 @@ describe('/api/articles/:article_id/comments', () => {
 				.get('/api/articles/1/comments')
 				.expect(200)
 				.then(({ body: { comments } }) => {
-					expect(comments).toBeInstanceOf(Array);
 					expect(comments).toHaveLength(11);
 					comments.forEach(comment => {
 						expect(comment).toMatchObject({
@@ -188,13 +186,23 @@ describe('/api/articles/:article_id/comments', () => {
 
 	describe('404: GET:', () => {
 		it('responds with status 404 when given an article_id that does not exist yet', () => {
-			return request(app).get('/api/articles/99999/comments').expect(404);
+			return request(app)
+				.get('/api/articles/99999/comments')
+				.expect(404)
+				.then(({ body: { msg } }) => {
+					expect(msg).toBe('Resource not found');
+				});
 		});
 	});
 
 	describe('400: GET:', () => {
 		it('responds with status 400 when given an article_id that can not exist', () => {
-			return request(app).get('/api/articles/someid/comments').expect(400);
+			return request(app)
+				.get('/api/articles/someid/comments')
+				.expect(400)
+				.then(({ body: { msg } }) => {
+					expect(msg).toBe('Bad request');
+				});
 		});
 	});
 });

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -152,3 +152,49 @@ describe('/api/articles', () => {
 		});
 	});
 });
+
+describe('/api/articles/:article_id/comments', () => {
+	describe('200: GET:', () => {
+		it('responds with status 200 and an array of comments with the right shape', () => {
+			return request(app)
+				.get('/api/articles/1/comments')
+				.expect(200)
+				.then(({ body: { comments } }) => {
+					expect(comments).toBeInstanceOf(Array);
+					expect(comments).toHaveLength(11);
+					comments.forEach(comment => {
+						expect(comment).toMatchObject({
+							comment_id: expect.any(Number),
+							body: expect.any(String),
+							article_id: 1,
+							author: expect.any(String),
+							votes: expect.any(Number),
+							created_at: expect.any(String),
+						});
+					});
+					expect(comments).toBeSortedBy('created_at', { descending: true });
+				});
+		});
+
+		it('responds with status 200 and an empty array when there is no comments', () => {
+			return request(app)
+				.get('/api/articles/2/comments')
+				.expect(200)
+				.then(({ body: { comments } }) => {
+					expect(comments).toEqual([]);
+				});
+		});
+	});
+
+	describe('404: GET:', () => {
+		it('responds with status 404 when given an article_id that does not exist yet', () => {
+			return request(app).get('/api/articles/99999/comments').expect(404);
+		});
+	});
+
+	describe('400: GET:', () => {
+		it('responds with status 400 when given an article_id that can not exist', () => {
+			return request(app).get('/api/articles/someid/comments').expect(400);
+		});
+	});
+});

--- a/app.js
+++ b/app.js
@@ -7,6 +7,10 @@ const app = express();
 app.get('/api/topics', controllers.getTopics);
 app.get('/api/articles', controllers.getArticles);
 app.get('/api/articles/:article_id', controllers.getArticleById);
+app.get(
+	'/api/articles/:article_id/comments',
+	controllers.getCommentsByArticleId
+);
 
 app.all('/*', errorHandlers.handleWrongPath);
 

--- a/controllers/app.controllers.js
+++ b/controllers/app.controllers.js
@@ -28,3 +28,14 @@ exports.getArticles = async (req, res, next) => {
 		next(err);
 	}
 };
+
+exports.getCommentsByArticleId = async (req, res, next) => {
+	const { article_id } = req.params;
+
+	try {
+		const comments = await models.fetchCommentsByArticleId(article_id);
+		res.status(200).send({ comments });
+	} catch (err) {
+		next(err);
+	}
+};

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -42,3 +42,30 @@ exports.fetchArticles = async () => {
 		return articleQuery.rows;
 	}
 };
+
+exports.fetchCommentsByArticleId = async id => {
+	const articleQuery = db.query(
+		`
+    SELECT * FROM articles
+    WHERE article_id = $1
+    `,
+		[id]
+	);
+
+	const commentsQuery = db.query(
+		`
+    SELECT * FROM comments
+    WHERE article_id = $1
+    ORDER BY created_at DESC
+  `,
+		[id]
+	);
+
+	const results = await Promise.all([articleQuery, commentsQuery]);
+
+	if (results[0].rowCount === 0) {
+		return Promise.reject({ code: 404 });
+	} else {
+		return results[1].rows;
+	}
+};


### PR DESCRIPTION
This pull request adds a new endpoint `/api/articles/:article_id/comments` to the API. This endpoint returns a list of comments associated with the specified `article_id`.