### PR TITLE
Add patch functionality to update votes on an article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -77,6 +77,71 @@ describe('/api/articles/:article_id', () => {
 		});
 	});
 
+	describe('201: PATCH: Votes', () => {
+		it('should respond with status 201 and an updated votes property, incremented by 1', () => {
+			const input = { inc_votes: 1 };
+
+			return request(app)
+				.patch('/api/articles/2')
+				.send(input)
+				.expect(201)
+				.then(({ body: { article } }) => {
+					expect(article).toMatchObject({
+						article_id: 2,
+						title: expect.any(String),
+						topic: expect.any(String),
+						author: expect.any(String),
+						body: expect.any(String),
+						created_at: expect.any(String),
+						votes: 1,
+						article_img_url: expect.any(String),
+					});
+				});
+		});
+
+		it('should respond with status 201 and an updated votes property, decremented by 1', () => {
+			const input = { inc_votes: -1 };
+
+			return request(app)
+				.patch('/api/articles/1')
+				.send(input)
+				.expect(201)
+				.then(({ body: { article } }) => {
+					expect(article).toMatchObject({
+						article_id: 1,
+						title: expect.any(String),
+						topic: expect.any(String),
+						author: expect.any(String),
+						body: expect.any(String),
+						created_at: expect.any(String),
+						votes: 99,
+						article_img_url: expect.any(String),
+					});
+				});
+		});
+
+		it('should respond with status 201 and ignore extra properties', () => {
+			const input = { inc_votes: 1, title: 'yahooo', votes: 999999 };
+
+			return request(app)
+				.patch('/api/articles/2')
+				.send(input)
+				.expect(201)
+				.then(({ body: { article } }) => {
+					expect(article).toMatchObject({
+						article_id: 2,
+						title: expect.any(String),
+						topic: expect.any(String),
+						author: expect.any(String),
+						body: expect.any(String),
+						created_at: expect.any(String),
+						votes: 1,
+						article_img_url: expect.any(String),
+					});
+				});
+		});
+	});
+
 	describe('400: GET:', () => {
 		it('responds with a 400 status code when given a value that is not a number', () => {
 			return request(app).get('/api/articles/not-a-num').expect(400);
@@ -100,6 +165,34 @@ describe('/api/articles/:article_id', () => {
 		it('responds with a message about the error', () => {
 			return request(app)
 				.get('/api/articles/999999')
+				.expect(404)
+				.then(({ body: { msg } }) => {
+					expect(msg).toBe('Resource not found');
+				});
+		});
+	});
+
+	describe('400: PATCH: Votes', () => {
+		it('should respond with status 400 when inc_votes is not present on request body', () => {
+			const input = { do_votes: 1 };
+
+			return request(app)
+				.patch('/api/articles/2')
+				.send(input)
+				.expect(400)
+				.then(({ body: { msg } }) => {
+					expect(msg).toBe('Bad request');
+				});
+		});
+	});
+
+	describe('404: PATCH: Votes', () => {
+		it('should respond with status 404 when article_id does not exist', () => {
+			const input = { inc_votes: 1 };
+
+			return request(app)
+				.patch('/api/articles/999999')
+				.send(input)
 				.expect(404)
 				.then(({ body: { msg } }) => {
 					expect(msg).toBe('Resource not found');

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ app.get(
 	controllers.getCommentsByArticleId
 );
 app.post('/api/articles/:article_id/comments', controllers.postComment);
+app.patch('/api/articles/:article_id', controllers.incrementArticleVotes);
 
 app.all('/*', errorHandlers.handleWrongPath);
 

--- a/controllers/app.controllers.js
+++ b/controllers/app.controllers.js
@@ -42,7 +42,9 @@ exports.getCommentsByArticleId = async (req, res, next) => {
 
 exports.postComment = async (req, res, next) => {
 	const { article_id } = req.params;
-	const { username, body } = req.body;
+	const {
+		body: { username, body },
+	} = req;
 
 	try {
 		if (!username || !body) {
@@ -59,6 +61,24 @@ exports.postComment = async (req, res, next) => {
 				);
 				res.status(201).send({ comment });
 			}
+		}
+	} catch (err) {
+		next(err);
+	}
+};
+
+exports.incrementArticleVotes = async (req, res, next) => {
+	const { article_id } = req.params;
+	const {
+		body: { inc_votes },
+	} = req;
+
+	try {
+		if (!inc_votes) {
+			next({ code: 400 });
+		} else {
+			const article = await models.updateArticleVotes(article_id, inc_votes);
+			res.status(201).send({ article });
 		}
 	} catch (err) {
 		next(err);


### PR DESCRIPTION
This pull request adds the functionality to update the votes property on an article using the endpoint /api/articles/:article_id. It allows users to update the number of votes for a specific article identified by its article_id