### PR TITLE
Refactoring so getting article by ID can also get a comment_count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -75,6 +75,16 @@ describe('/api/articles/:article_id', () => {
 					});
 				});
 		});
+
+    it('should have a key named comment_count', () => {
+			return request(app)
+				.get('/api/articles/1')
+				.expect(200)
+				.then(({ body: { article } }) => {
+					expect(article).toHaveProperty('comment_count');
+					expect(article.comment_count).toBe('11');
+				});
+		});
 	});
 
 	describe('201: PATCH: Votes', () => {

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -22,7 +22,18 @@ exports.fetchTopics = async () => {
 
 exports.fetchArticleById = async id => {
 	const results = await db.query(
-		'SELECT * FROM articles WHERE article_id = $1',
+		`
+    SELECT articles.*, COALESCE(comments.comment_count, 0) AS comment_count
+    FROM articles
+    LEFT JOIN (
+    SELECT article_id, COUNT(article_id) AS comment_count
+    FROM comments
+    GROUP BY article_id
+    ) comments
+    ON articles.article_id = comments.article_id 
+    WHERE articles.article_id = $1
+    ORDER BY articles.created_at DESC;
+    `,
 		[id]
 	);
 


### PR DESCRIPTION
getArticleById now gets a comment count when it queries the db